### PR TITLE
Ensure this package runs on Node.js 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: npm install
       - run: npm test
 
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://npm.pkg.github.com/
       - run: npm publish
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: npm install
       - run: npm test
 
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: npm publish
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,10 @@
 			"devDependencies": {
 				"jest": "^27.5.1",
 				"rewire": "^6.0.0"
+			},
+			"engines": {
+				"node": "14.x || 16.x || 18.x",
+				"npm": "7.x || 8.x || 9.x"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,16 @@
 		"jest": "^27.5.1",
 		"rewire": "^6.0.0"
 	},
+	"engines": {
+		"node": "14.x || 16.x || 18.x",
+		"npm": "7.x || 8.x || 9.x"
+	},
 	"scripts": {
 		"test": "jest --forceExit --runInBand ."
 	},
-	"author": "Jesus Redondo"
+	"author": "Jesus Redondo",
+	"volta": {
+		"node": "18.15.0",
+		"npm": "9.6.0"
+	}
 }


### PR DESCRIPTION
With the migration to Node.js 18 we need to ensure that our packages run on the latest version. We've also updated the default version and added a Volta config so that local development also uses Node.js 18.